### PR TITLE
Add a prompt to confirm the parent directory creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Add an option to set the default name for compatibility with legacy behavior.
+- Add a prompt to confirm the parent directory creation.
+- Remove the abort notification.
 
 ## 0.2.0 - 2024-10-01
 

--- a/l10n/bundle.l10n.ja.json
+++ b/l10n/bundle.l10n.ja.json
@@ -1,8 +1,15 @@
 {
     "This file system is not writable.": "このファイルシステムは書き込み不可能です。",
-    "Failed to parse the default folder path. Please check the extension settings.": "フォルダーパスのパースに失敗しました。拡張機能の設定を確認してください。",
+    "Failed to parse the default folder: {0}": "デフォルトフォルダーのパースに失敗しました: {0}",
+    "Failed to parse the default name: {0}": "デフォルト名のパースに失敗しました: {0}",
     "Input your project folder path.": "プロジェクトフォルダーのパスを入力してください。",
-    "No input. Aborted.": "入力がありませんでした。中断します。",
-    "Failed to parse the folder path: {0}": "フォルダーパスのパースに失敗しました: {0}",
+    "Failed to parse the project folder path: {0}": "プロジェクトフォルダーのパスのパースに失敗しました: {0}",
+    "The parent is not a directory: {0}": "親がディレクトリーではありませんでした: {0}",
+    "Failed to check the parent directory: {0}": "親ディレクトリーのチェックに失敗しました: {0}",
+    "Create the parent directory": "親ディレクトリーを作成する",
+    "Cancel": "キャンセル",
+    "Abort the operation": "操作を中断します",
+    "The parent directory does not exist.": "親ディレクトリーが存在しませんでした。",
+    "Do you want to create the parent directory?": "親ディレクトリーを作成しますか?",
     "Failed to create the directory: {0}": "ディレクトリーの作成に失敗しました: {0}"
 }

--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -1,8 +1,15 @@
 {
     "This file system is not writable.": "This file system is not writable.",
-    "Failed to parse the default folder path. Please check the extension settings.": "Failed to parse the default folder path. Please check the extension settings.",
+    "Failed to parse the default folder: {0}": "Failed to parse the default folder: {0}",
+    "Failed to parse the default name: {0}": "Failed to parse the default name: {0}",
     "Input your project folder path.": "Input your project folder path.",
-    "No input. Aborted.": "No input. Aborted.",
-    "Failed to parse the folder path: {0}": "Failed to parse the folder path: {0}",
+    "Failed to parse the project folder path: {0}": "Failed to parse the project folder path: {0}",
+    "The parent is not a directory: {0}": "The parent is not a directory: {0}",
+    "Failed to check the parent directory: {0}": "Failed to check the parent directory: {0}",
+    "Create the parent directory": "Create the parent directory",
+    "Cancel": "Cancel",
+    "Abort the operation": "Abort the operation",
+    "The parent directory does not exist.": "The parent directory does not exist.",
+    "Do you want to create the parent directory?": "Do you want to create the parent directory?",
     "Failed to create the directory: {0}": "Failed to create the directory: {0}"
 }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -14,6 +14,8 @@ function generateRandomName() {
 }
 
 export async function create() {
+    // Check the file system
+
     if (!vscode.workspace.fs.isWritableFileSystem("file")) {
         await vscode.window.showErrorMessage(
             vscode.l10n.t("This file system is not writable."),
@@ -21,6 +23,8 @@ export async function create() {
 
         return
     }
+
+    // Get configuration
 
     const defaultFolder = vscode.workspace
         .getConfiguration("create-project")
@@ -30,23 +34,40 @@ export async function create() {
         .getConfiguration("create-project")
         .get<string>("defaultName", "{randomName}")
 
-    const name = format(defaultName, { randomName: generateRandomName })
+    // Check `defaultFolder`
 
-    let value: string
+    let defaultFolderUri: vscode.Uri
 
     try {
-        value = vscode.Uri.joinPath(
-            vscode.Uri.file(defaultFolder),
-            name,
-        ).fsPath.toString()
+        defaultFolderUri = vscode.Uri.file(defaultFolder)
     } catch {
         await vscode.window.showErrorMessage(
             vscode.l10n.t(
-                "Failed to parse the default folder path. Please check the extension settings.",
+                "Failed to parse the default folder: {0}",
+                defaultFolder,
             ),
         )
         return
     }
+
+    // Format `defaultName`
+
+    const name = format(defaultName, { randomName: generateRandomName })
+
+    // Check `defaultName`
+
+    let value: string
+
+    try {
+        value = vscode.Uri.joinPath(defaultFolderUri, name).path
+    } catch {
+        await vscode.window.showErrorMessage(
+            vscode.l10n.t("Failed to parse the default name: {0}", defaultName),
+        )
+        return
+    }
+
+    // Ask the project folder path
 
     const input = await vscode.window.showInputBox({
         title: vscode.l10n.t("Input your project folder path."),
@@ -62,30 +83,36 @@ export async function create() {
         return
     }
 
+    // Parse the project folder path
+
     let uri: vscode.Uri
 
     try {
         uri = vscode.Uri.file(input)
     } catch {
         await vscode.window.showErrorMessage(
-            vscode.l10n.t("Failed to parse the folder path: {0}", input),
-        )
-
-        return
-    }
-
-    try {
-        await vscode.workspace.fs.createDirectory(uri)
-    } catch {
-        await vscode.window.showErrorMessage(
             vscode.l10n.t(
-                "Failed to create the directory: {0}",
-                uri.toString(),
+                "Failed to parse the project folder path: {0}",
+                input,
             ),
         )
 
         return
     }
+
+    // Create the directory
+
+    try {
+        await vscode.workspace.fs.createDirectory(uri)
+    } catch {
+        await vscode.window.showErrorMessage(
+            vscode.l10n.t("Failed to create the directory: {0}", uri.path),
+        )
+
+        return
+    }
+
+    // Open the directory
 
     await vscode.commands.executeCommand("vscode.openFolder", uri)
 }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -76,10 +76,6 @@ export async function create() {
     })
 
     if (!input) {
-        await vscode.window.showInformationMessage(
-            vscode.l10n.t("No input. Aborted."),
-        )
-
         return
     }
 


### PR DESCRIPTION
Current implementation allows the user to create a parent directory even if the input is unintentional. This PR adds a prompt before creating the parent directory to confirm the user's intention.

Related: #2