### PR TITLE
Add "Create Empty Project" button to the explorer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## Unreleased
 
 - Add an option to set the default name for compatibility with legacy behavior.
+- Add "Create Empty Project" button to the explorer. It is shown when no folder is open.
 - Add a prompt to confirm the parent directory creation.
+- Change the command name to "Create New Empty Project" form "Create New Project" for consistency and clarity.
 - Remove the abort notification.
 
 ## 0.2.0 - 2024-10-01

--- a/package.json
+++ b/package.json
@@ -44,6 +44,12 @@
                     "type": "string",
                     "description": "%extension.create-project.configuration.defaultName.description%",
                     "scope": "resource"
+                },
+                "create-project.explorer.enabled": {
+                    "type": "boolean",
+                    "description": "%extension.create-project.configuration.explorer.enabled.description%",
+                    "default": true,
+                    "scope": "resource"
                 }
             }
         },
@@ -53,7 +59,14 @@
                     "command": "create-project.create"
                 }
             ]
-        }
+        },
+        "viewsWelcome": [
+            {
+                "view": "explorer",
+                "contents": "%extension.create-project.viewsWelcome.contents%",
+                "when": "workspaceFolderCount == 0 && config.create-project.explorer.enabled"
+            }
+        ]
     },
     "scripts": {
         "vscode:prepublish": "npm run build",

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -3,5 +3,7 @@
     "extension.create-project.command.create.title": "プロジェクトの作成",
     "extension.create-project.configuration.title": "プロジェクトの作成",
     "extension.create-project.configuration.defaultFolder.description": "新しいフォルダが作成される先のデフォルトのフォルダーを制御します。",
-    "extension.create-project.configuration.defaultName.description": "新しいプロジェクトフォルダーのデフォルトの名前を制御します。 `{randomName}` はランダムな名前に置き換えられます。 エスケープするには `{{` と `}}` を使用します。 デフォルトは `{randomName}` です。"
+    "extension.create-project.configuration.defaultName.description": "新しいプロジェクトフォルダーのデフォルトの名前を制御します。 `{randomName}` はランダムな名前に置き換えられます。 エスケープするには `{{` と `}}` を使用します。 デフォルトは `{randomName}` です。",
+    "extension.create-project.configuration.explorer.enabled.description": "エクスプローラーサイドバーに「空のプロジェクトを作成」ボタンが表示されるかどうかを制御します",
+    "extension.create-project.viewsWelcome.contents": "空のプロジェクトを作成できます。\n[空のプロジェクトを作成](command:create-project.create)"
 }

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -1,6 +1,6 @@
 {
     "extension.create-project.command.category": "プロジェクトの作成",
-    "extension.create-project.command.create.title": "プロジェクトの作成",
+    "extension.create-project.command.create.title": "空のプロジェクトの作成",
     "extension.create-project.configuration.title": "プロジェクトの作成",
     "extension.create-project.configuration.defaultFolder.description": "新しいフォルダが作成される先のデフォルトのフォルダーを制御します。",
     "extension.create-project.configuration.defaultName.description": "新しいプロジェクトフォルダーのデフォルトの名前を制御します。 `{randomName}` はランダムな名前に置き換えられます。 エスケープするには `{{` と `}}` を使用します。 デフォルトは `{randomName}` です。",

--- a/package.nls.json
+++ b/package.nls.json
@@ -3,5 +3,7 @@
     "extension.create-project.command.create.title": "Create a New Project",
     "extension.create-project.configuration.title": "Create Project",
     "extension.create-project.configuration.defaultFolder.description": "Controls the default folder to which the new project folder will be created.",
-    "extension.create-project.configuration.defaultName.description": "Controls the default name of the new project folder. `{randomName}` will be replaced with a random name. Use `{{` and `}}` to escape. Default is `{randomName}`."
+    "extension.create-project.configuration.defaultName.description": "Controls the default name of the new project folder. `{randomName}` will be replaced with a random name. Use `{{` and `}}` to escape. Default is `{randomName}`.",
+    "extension.create-project.configuration.explorer.enabled.description": "Controls whether the 'Create Empty Project' button is shown in the explorer sidebar",
+    "extension.create-project.viewsWelcome.contents": "You can also create a new empty project.\n[Create Empty Project](command:create-project.create)"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,6 @@
 {
     "extension.create-project.command.category": "Create Project",
-    "extension.create-project.command.create.title": "Create a New Project",
+    "extension.create-project.command.create.title": "Create New Empty Project",
     "extension.create-project.configuration.title": "Create Project",
     "extension.create-project.configuration.defaultFolder.description": "Controls the default folder to which the new project folder will be created.",
     "extension.create-project.configuration.defaultName.description": "Controls the default name of the new project folder. `{randomName}` will be replaced with a random name. Use `{{` and `}}` to escape. Default is `{randomName}`.",


### PR DESCRIPTION
NOTE: This PR also change the command name to "Create New Empty Project" form "Create New Project" for consistency while keeping compatibility (i.e. typing "new" in the command palette suggests this command).

Closes #3